### PR TITLE
fixing paths json to match site in cloudmanager

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -1,5 +1,5 @@
 {
   "mappings": [
-    "/content/aem-edge-xwalk-mcmatt/:/"
+    "/content/aem-edge-getting-started-site/:/"
   ]
 }


### PR DESCRIPTION
update paths json to match the path in the cloudmanager for the site to make mappings work

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-edge-xwalk-mcmatt--mckmatt.aem.live/
- After: https://<branch>--aem-edge-xwalk-mcmatt--mckmatt.aem.live/
